### PR TITLE
add parameter to onClosed

### DIFF
--- a/Notification.js
+++ b/Notification.js
@@ -75,14 +75,14 @@ class Notification extends Component {
     });
   }
 
-  closeNotification(done = () => {}) {
+  closeNotification(done) {
     this.props.onClosing && this.props.onClosing();
     Animated.timing(this.state.animatedValue, {
       toValue: 0,
       duration: this.props.openCloseDuration,
     }).start(() => {
-      done();
-      this.props.onClosed && this.props.onClosed();
+      done && done();
+      this.props.onClosed && this.props.onClosed(done != null);
     });
   }
 


### PR DESCRIPTION
onClosed will be fired with a parameter that informs if notification is being closed just to show again,
in my case, I was hiding notification in onClosed event, but in case that it will be shown again, it should not be removed.